### PR TITLE
Fix bug where state would always flip back to off when the thermostat is in manual mode

### DIFF
--- a/lib/NuHeatThermostat.js
+++ b/lib/NuHeatThermostat.js
@@ -101,7 +101,7 @@ module.exports = class NuHeatThermostat {
                 setPointTemperature = 10;
             if (setPointTemperature > 38)
                 setPointTemperature = 38;
-            this.log.debug("Setpoint temperature is" + setPointTemperature + "°C", this.deviceData.name);
+            this.log.debug("Setpoint temperature is " + setPointTemperature + "°C", this.deviceData.name);
             this.accessory
                 .getService(ThermostatService)
                     .getCharacteristic(Characteristic.TargetTemperature)
@@ -147,12 +147,12 @@ module.exports = class NuHeatThermostat {
             case 0:
                 // emergency heat
             case 1:
-                // heat
+                // heat (in auto mode)
                 return Characteristic.TargetHeatingCoolingState.HEAT;
                 break;
             case 2:
-                // off
-                return Characteristic.TargetHeatingCoolingState.OFF;
+                // heat (in manual mode)
+                return Characteristic.TargetHeatingCoolingState.HEAT;
                 break;
             case 3:
                 // cool
@@ -170,29 +170,6 @@ module.exports = class NuHeatThermostat {
                 // "Southern Away" humidity control
             default:
                 return Characteristic.TargetHeatingCoolingState.OFF;
-        }
-    }
- 
-    toNuHeatisHeatingCoolingSystem(isHeatingCoolingSystem) {
-        switch (isHeatingCoolingSystem) {
-            case Characteristic.TargetHeatingCoolingState.OFF:
-                // off
-                return 2;
-                break;
-            case Characteristic.TargetHeatingCoolingState.HEAT:
-                // heat
-                return 1
-                break;
-            case Characteristic.TargetHeatingCoolingState.COOL:
-                // cool
-                return 3
-                break;
-            case Characteristic.TargetHeatingCoolingState.AUTO:
-                // auto
-                return 4
-                break;
-            default:
-                return 0;
         }
     }
 }


### PR DESCRIPTION
The code currently seems to be using the operating mode reported by the thermostat to update the `TargetHeatingCoolingState`. However, if the Nuheat thermostat was set to "Manual" (under Settings -> Setup/Preferences -> Operating Mode -> Manual), then the homebridge plugin would keep overwriting the `TargetHeatingCoolingState` to off. This would make it impossible to control the accessory since anytime you would try to set the temperature or set the state to "Heat" in the Home app it would flip back to off.

I believe this problem has been seen by other people too, and was reported in these issues:  
https://github.com/senorshaun/homebridge-nuheat/issues/15
https://github.com/senorshaun/homebridge-nuheat/issues/18

